### PR TITLE
Update tlp-thumbnail-selector.js.es6

### DIFF
--- a/javascripts/discourse/controllers/tlp-thumbnail-selector.js.es6
+++ b/javascripts/discourse/controllers/tlp-thumbnail-selector.js.es6
@@ -1,4 +1,4 @@
-import { default as computed } from 'ember-addons/ember-computed-decorators';
+import { default as computed } from 'discourse-common/utils/decorators';
 import ModalFunctionality from 'discourse/mixins/modal-functionality';
 import { bufferedProperty } from "discourse/mixins/buffered-content";
 


### PR DESCRIPTION
ember-addons/ember-computed-decorators is now deprecated.